### PR TITLE
Allow preceding zeroes in numbers even though it's a bad idea to use them

### DIFF
--- a/lib/cronex/description/base.rb
+++ b/lib/cronex/description/base.rb
@@ -50,7 +50,7 @@ module Cronex
     end
 
     def plural(expression, singular, plural)
-      number = Cronex::Utils.number?(expression)
+      number = Cronex::Utils.number(expression)
       return plural if number && number > 1
       return plural if expression.include?(',')
       singular

--- a/lib/cronex/description/day_of_week.rb
+++ b/lib/cronex/description/day_of_week.rb
@@ -9,7 +9,7 @@ module Cronex
       end
 
       if Cronex::Utils.number?(exp)
-        dow_num = Integer(exp)
+        dow_num = exp.to_i
         zero_based_dow = options[:zero_based_dow]
         invalid_dow = !zero_based_dow && dow_num <= 1
         if invalid_dow || (zero_based_dow && dow_num == 0)

--- a/lib/cronex/description/month.rb
+++ b/lib/cronex/description/month.rb
@@ -1,7 +1,7 @@
 module Cronex
   class MonthDescription < Description
     def single_item_description(expression)
-      resources.get(DateTime.new(Time.now.year, Integer(expression), 1).strftime('%B').downcase)
+      resources.get(DateTime.new(Time.now.year, expression.to_i, 1).strftime('%B').downcase)
     end
 
     def interval_description_format(expression)

--- a/lib/cronex/description/year.rb
+++ b/lib/cronex/description/year.rb
@@ -1,7 +1,7 @@
 module Cronex
   class YearDescription < Description
     def single_item_description(expression)
-      DateTime.new(Integer(expression)).strftime('%Y')
+      DateTime.new(expression.to_i).strftime('%Y')
     end
 
     def interval_description_format(expression)

--- a/lib/cronex/exp_descriptor.rb
+++ b/lib/cronex/exp_descriptor.rb
@@ -113,7 +113,7 @@ module Cronex
       else
         match = exp.match(/(\d{1,2}W)|(W\d{1,2})/)
         if match
-          day_num = Integer(match[0].gsub('W', ''))
+          day_num = match[0].gsub('W', '').to_i
           day_str = day_num == 1 ? resources.get('first_weekday') : format(resources.get('weekday_nearest_day'), day_num)
           description = format(', ' + resources.get('on_the_of_the_month'), day_str)
         else

--- a/lib/cronex/utils.rb
+++ b/lib/cronex/utils.rb
@@ -11,7 +11,11 @@ module Cronex
     end
 
     def number?(str)
-      Integer(str) rescue nil
+      !!number(str)
+    end
+
+    def number(str)
+      Integer(str.sub(/^0*(\d+)/,'\1')) rescue nil
     end
 
     def day_of_week_name(number)
@@ -27,14 +31,14 @@ module Cronex
     end
 
     def format_time(hour_expression, minute_expression, second_expression = '')
-      hour = Integer(hour_expression)
+      hour = hour_expression.to_i
       period = hour >= 12 ? 'PM' : 'AM'
       hour -= 12 if hour > 12
-      minute = Integer(minute_expression)
+      minute = minute_expression.to_i
       minute = format('%02d', minute)
       second = ''
       if Cronex::Utils.present?(second_expression)
-        second = Integer(second_expression)
+        second = second_expression.to_i
         second = ':' + format('%02d', second)
       end
       format('%s:%s%s %s', hour, minute, second, period)


### PR DESCRIPTION
Since these functions are only used when creating a human-readable format, it should be safe to allow them here.

Before this, numbers with a preceding zero would only work if 8 or less, because they would be treated as octal.
